### PR TITLE
Set `external_contributors` to default to `false`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export const DefaultOpsBotConfig: OpsBotConfig = {
   branch_checker: false,
   label_checker: false,
   release_drafter: false,
-  external_contributors: true,
+  external_contributors: false,
 };
 
 /**


### PR DESCRIPTION
In hindsight, this should've been set to a default value of `false`. We can potentially set it to `true` in the future if we want it to be an "opt-out" feature.