### PR TITLE
Add `Rerun Tests` plugin

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,3 +41,5 @@ jobs:
           MORPHEUS_ORG_APP_ID: ${{ secrets.MORPHEUS_ORG_APP_ID }}
           MORPHEUS_ORG_WEBHOOK_SECRET: ${{ secrets.MORPHEUS_ORG_WEBHOOK_SECRET }}
           MORPHEUS_ORG_PRIVATE_KEY: ${{ secrets.MORPHEUS_ORG_PRIVATE_KEY }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The plugins are listed in the [src/plugins](./src/plugins) folder.
 - **Auto Merger** - Automatically merges PRs that include the `@gpucibot merge` comment and meet the merge criteria outlined in [https://docs.rapids.ai/resources/auto-merger/](https://docs.rapids.ai/resources/auto-merger/).
 - **Branch Checker** - Set a status on PRs that checks whether they are targeting either the repo's _default branch_ or _default branch + 1_
 - **Copy PRs** - Copies pull request branches from their forked repository to the source repository for testing. If a pull request is from a GitHub author that is not a member of the RAPIDS GitHub organization, it will require an `okay to test` comment be submitted to the PR by a member of the RAPIDS organization before the forked code is copied to the source repository.
+- **Rerun Tests** - Listens for comments on PRs and runs a new Jenkins build if the comment matches a particular regular expression.
 
 ## Deployment
 

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -12,6 +12,9 @@ provider:
     shouldStartNameWithService: true
   deploymentBucket:
     name: rapids-serverless-deployments
+  environment:
+    JENKINS_USERNAME: ${env:JENKINS_USERNAME}
+    JENKINS_TOKEN: ${env:JENKINS_TOKEN}
 
 functions:
   handleProbot:

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -3,7 +3,7 @@ service: gpuci-serverless-ops-bot-probot
 provider:
   name: aws
   region: us-east-2
-  timeout: 300
+  timeout: 30
   memorySize: 1024
   stage: dev
   runtime: nodejs14.x

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * Format of the .github/ops-bot.yaml file that can be
@@ -24,6 +24,7 @@ export type OpsBotConfig = {
   label_checker: boolean;
   release_drafter: boolean;
   copy_prs: boolean;
+  rerun_tests: boolean;
 };
 
 /**
@@ -35,6 +36,7 @@ export const DefaultOpsBotConfig: OpsBotConfig = {
   label_checker: false,
   release_drafter: false,
   copy_prs: false,
+  rerun_tests: false,
 };
 
 /**

--- a/src/plugins/RerunTests/index.ts
+++ b/src/plugins/RerunTests/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Probot } from "probot";
+import { RerunTests } from "./rerun_tests";
+
+export const initLabelChecker = (app: Probot) => {
+  app.on(["issue_comment.created"], async (context) => {
+    await new RerunTests(context).maybeRerunTests();
+  });
+};

--- a/src/plugins/RerunTests/rerun_tests.ts
+++ b/src/plugins/RerunTests/rerun_tests.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from "axios";
+import { featureIsDisabled, issueIsPR } from "../../shared";
+import { IssueCommentContext } from "../../types";
+
+export class RerunTests {
+  public context: IssueCommentContext;
+
+  constructor(context: IssueCommentContext) {
+    this.context = context;
+  }
+
+  async maybeRerunTests(): Promise<any> {
+    const context = this.context;
+
+    if (await featureIsDisabled(context, "rerun_tests")) return;
+
+    if (!issueIsPR(context)) return;
+    if (!context.payload.comment.body.match(/.*(re)?run\W+tests.*/)) return;
+
+    const repo = context.payload.repository.name;
+    const prNumber = context.payload.issue.number;
+    const isPrivate = context.payload.repository.private;
+    const jenkinsServer = "https://gpuci.gpuopenanalytics.com";
+    const postUrl = `${jenkinsServer}/job/${
+      isPrivate ? "private-repos-ci/job/" : ""
+    }orgs/job/${repo}/job/pull-request%252F${prNumber}/build`;
+
+    // Response looks like `Jenkins-Crumb:<crumb>`
+    const { data: resp } = await axios.get<string>(
+      `${jenkinsServer}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)`,
+      {
+        auth: {
+          username: process.env.JENKINS_USERNAME as string,
+          password: process.env.JENKINS_TOKEN as string,
+        },
+      }
+    );
+
+    const jenkinsCrumb = resp.split(":")[1];
+
+    console.log("Posting to:", postUrl);
+    try {
+      await axios.post(postUrl, null, {
+        headers: {
+          "Jenkins-Crumb": jenkinsCrumb,
+        },
+        auth: {
+          username: process.env.JENKINS_USERNAME as string,
+          password: process.env.JENKINS_TOKEN as string,
+        },
+      });
+    } catch (error) {
+      console.error(`Could not rerun tests for ${repo} PR number ${prNumber}:`);
+      console.error(error);
+    }
+  }
+}

--- a/src/plugins/RerunTests/rerun_tests.ts
+++ b/src/plugins/RerunTests/rerun_tests.ts
@@ -15,7 +15,7 @@
  */
 
 import axios from "axios";
-import { featureIsDisabled, issueIsPR } from "../../shared";
+import { featureIsDisabled, getPRBranchName, issueIsPR } from "../../shared";
 import { IssueCommentContext } from "../../types";
 
 export class RerunTests {
@@ -39,7 +39,9 @@ export class RerunTests {
     const jenkinsServer = "https://gpuci.gpuopenanalytics.com";
     const postUrl = `${jenkinsServer}/job/${
       isPrivate ? "private-repos-ci/job/" : ""
-    }orgs/job/${repo}/job/pull-request%252F${prNumber}/build`;
+    }orgs/job/${repo}/job/${encodeURIComponent(
+      getPRBranchName(prNumber)
+    )}/build`;
 
     // Response looks like `Jenkins-Crumb:<crumb>`
     const { data: resp } = await axios.get<string>(

--- a/test/fixtures/contexts/issue_comment.ts
+++ b/test/fixtures/contexts/issue_comment.ts
@@ -18,6 +18,7 @@ import { makeContext } from "./base";
 import { IssueCommentContext } from "../../../src/types";
 type RespParams = {
   is_pr?: boolean;
+  is_private?: boolean;
   body?: string;
   commentUsername?: string;
   issueUsername?: string;
@@ -25,6 +26,7 @@ type RespParams = {
 
 export const makeIssueCommentContext = ({
   is_pr = false,
+  is_private = false,
   body = "some random text",
   commentUsername = "someone",
   issueUsername = "issue_user",
@@ -45,6 +47,7 @@ export const makeIssueCommentContext = ({
     repository: {
       name: "cudf",
       full_name: "rapidsai/cudf",
+      private: is_private,
       owner: {
         login: "rapidsai",
       },

--- a/test/rerun_tests.test.ts
+++ b/test/rerun_tests.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RerunTests } from "../src/plugins/RerunTests/rerun_tests";
+import { makeIssueCommentContext } from "./fixtures/contexts/issue_comment";
+import { makeConfigReponse } from "./fixtures/responses/get_config";
+import {
+  mockConfigGet,
+  mockContextRepo,
+  mockCreateCommitStatus,
+} from "./mocks";
+import { default as repoResp } from "./fixtures/responses/context_repo.json";
+import axios from "axios";
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Rerun Tests", () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    mockCreateCommitStatus.mockReset();
+    mockedAxios.get.mockReset();
+    mockedAxios.post.mockReset();
+    jest.resetModules();
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  beforeAll(() => {
+    mockContextRepo.mockReturnValue(repoResp);
+    mockConfigGet.mockResolvedValue(makeConfigReponse({ rerun_tests: true }));
+  });
+
+  test("issue is not a PR", async () => {
+    const context = makeIssueCommentContext({ is_pr: false });
+
+    await new RerunTests(context).maybeRerunTests();
+
+    expect(mockedAxios.get).not.toBeCalled();
+    expect(mockedAxios.post).not.toBeCalled();
+  });
+
+  test("PR comment is not rerun tests", async () => {
+    const context = makeIssueCommentContext({
+      is_pr: true,
+      body: "some random body",
+    });
+
+    await new RerunTests(context).maybeRerunTests();
+
+    expect(mockedAxios.get).not.toBeCalled();
+    expect(mockedAxios.post).not.toBeCalled();
+  });
+
+  test.each([
+    [
+      true,
+      "https://gpuci.gpuopenanalytics.com/job/private-repos-ci/job/orgs/job/cudf/job/pull-request%252F468/build",
+    ],
+    [
+      false,
+      "https://gpuci.gpuopenanalytics.com/job/orgs/job/cudf/job/pull-request%252F468/build",
+    ],
+  ])("PR comment is rerun tests", async (isPrivateRepo, expectedPostUrl) => {
+    const context = makeIssueCommentContext({
+      is_pr: true,
+      is_private: isPrivateRepo,
+      body: "rerun tests",
+    });
+    mockedAxios.get.mockResolvedValueOnce({ data: "Jenkins-Crumb:abc1234" });
+    process.env.JENKINS_USERNAME = "jenkinsuser";
+    process.env.JENKINS_TOKEN = "jenkinstoken";
+
+    await new RerunTests(context).maybeRerunTests();
+
+    expect(mockedAxios.get).toBeCalledTimes(1);
+    expect(mockedAxios.post).toBeCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      "https://gpuci.gpuopenanalytics.com/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)",
+      {
+        auth: {
+          username: "jenkinsuser",
+          password: "jenkinstoken",
+        },
+      }
+    );
+    expect(mockedAxios.post).toHaveBeenCalledWith(expectedPostUrl, null, {
+      auth: {
+        username: "jenkinsuser",
+        password: "jenkinstoken",
+      },
+      headers: {
+        "Jenkins-Crumb": "abc1234",
+      },
+    });
+  });
+});

--- a/test/rerun_tests.test.ts
+++ b/test/rerun_tests.test.ts
@@ -71,11 +71,11 @@ describe("Rerun Tests", () => {
   test.each([
     [
       true,
-      "https://gpuci.gpuopenanalytics.com/job/private-repos-ci/job/orgs/job/cudf/job/pull-request%252F468/build",
+      "https://gpuci.gpuopenanalytics.com/job/private-repos-ci/job/orgs/job/cudf/job/pull-request%2F468/build",
     ],
     [
       false,
-      "https://gpuci.gpuopenanalytics.com/job/orgs/job/cudf/job/pull-request%252F468/build",
+      "https://gpuci.gpuopenanalytics.com/job/orgs/job/cudf/job/pull-request%2F468/build",
     ],
   ])("PR comment is rerun tests", async (isPrivateRepo, expectedPostUrl) => {
     const context = makeIssueCommentContext({


### PR DESCRIPTION
This PR adds a `Rerun Tests` plugin, which listens for comments on a PR and triggers a new CI build if the comment matches a particular regular expression.