### PR TITLE
Fix hard-coded org name

### DIFF
--- a/test/copy_prs.test.ts
+++ b/test/copy_prs.test.ts
@@ -79,7 +79,7 @@ describe("External Contributors", () => {
       owner: prContext.payload.repository.owner.login,
       repo: prContext.payload.repository.name,
       issue_number: prContext.payload.pull_request.id,
-      body: "Pull requests from external contributors require approval from a RAPIDS organization member before CI can begin.",
+      body: "Pull requests from external contributors require approval from a `rapidsai` organization member before CI can begin.",
     });
     expect(mockCreateRef).toBeCalledTimes(0);
   });


### PR DESCRIPTION
Since the `ops-bot` is used in other organizations besides `rapidsai`, this PR removes a hardcoded reference to the `RAPIDS` organization and replaces it with a dynamic reference based on the source of the webhook.