### PR TITLE
Update comment for external contributors

### DIFF
--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -55,7 +55,7 @@ export class PRCopyPRs {
         owner: orgName,
         repo: payload.repository.name,
         issue_number: payload.pull_request.number,
-        body: `Pull requests from external contributors require approval from a \`${orgName}\` organization member before CI can begin.`,
+        body: `Pull requests from external contributors require approval from a \`${orgName}\` organization member with \`write\` or \`admin\` permissions before CI can begin.`,
       });
       return;
     }

--- a/test/copy_prs.test.ts
+++ b/test/copy_prs.test.ts
@@ -79,7 +79,7 @@ describe("External Contributors", () => {
       owner: prContext.payload.repository.owner.login,
       repo: prContext.payload.repository.name,
       issue_number: prContext.payload.pull_request.id,
-      body: "Pull requests from external contributors require approval from a `rapidsai` organization member before CI can begin.",
+      body: "Pull requests from external contributors require approval from a `rapidsai` organization member with `write` or `admin` permissions before CI can begin.",
     });
     expect(mockCreateRef).toBeCalledTimes(0);
   });


### PR DESCRIPTION
This PR updates the comment for PRs from external contributors to clarify which members can approve the PR for testing.