### PR TITLE
Add `test last commit` functionality to `CopyPRs` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The plugins are listed in the [src/plugins](./src/plugins) folder.
 - **Release Drafter** - Opens up a draft release on GitHub anytime a PR is merged to a versioned branch (i.e. `branch-0.17`, `branch-0.18`, etc.). The draft body includes a categorized changelog consisting of the PRs that have been merged on that branch.
 - **Auto Merger** - Automatically merges PRs that include the `@gpucibot merge` comment and meet the merge criteria outlined in [https://docs.rapids.ai/resources/auto-merger/](https://docs.rapids.ai/resources/auto-merger/).
 - **Branch Checker** - Set a status on PRs that checks whether they are targeting either the repo's _default branch_ or _default branch + 1_
-- **Copy PRs** - Copies pull request branches from their forked repository to the source repository for testing. If a pull request is from a GitHub author that is not a member of the RAPIDS GitHub organization, it will require an `okay to test` comment be submitted to the PR by a member of the RAPIDS organization before the forked code is copied to the source repository.
+- **Copy PRs** - Copies pull request branches from their forked repository to the source repository for testing. If a pull request is from a GitHub author that is not a member of the RAPIDS GitHub organization, it will require an `okay to test` comment be submitted to the PR by a member of the RAPIDS organization before the forked code is copied to the source repository. `okay to test` will also allow subsequent commits to be tested. To test a single commit, you can comment `test last commit` instead.
 - **Rerun Tests** - Listens for comments on PRs and runs a new Jenkins build if the comment matches a particular regular expression.
 
 ## Deployment

--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -20,6 +20,7 @@ import {
   getPRBranchName,
   isOkayToTestComment,
   isOrgMember,
+  updateOrCreateBranch,
   validCommentsExistByPredicate,
   WRITE_PERMISSION,
 } from "../../shared";
@@ -75,22 +76,13 @@ export class PRCopyPRs {
           (comment) => isOkayToTestComment(comment.body || "") && !!comment.user
         ))
       ) {
-        try {
-          await this.context.octokit.rest.git.updateRef({
-            ref: `heads/${getPRBranchName(payload.pull_request.number)}`,
-            repo: payload.repository.name,
-            owner: orgName,
-            sha: payload.pull_request.head.sha,
-            force: true,
-          });
-        } catch {
-          await this.context.octokit.rest.git.createRef({
-            ref: `refs/heads/${getPRBranchName(payload.pull_request.number)}`,
-            repo: payload.repository.name,
-            owner: orgName,
-            sha: payload.pull_request.head.sha,
-          });
-        }
+        await updateOrCreateBranch(
+          this.context.octokit,
+          getPRBranchName(payload.pull_request.number),
+          payload.repository.name,
+          orgName,
+          payload.pull_request.head.sha
+        );
       }
       return;
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -213,3 +213,37 @@ export const isOrgMember = async (
   } catch (_) {}
   return isOrgMember;
 };
+
+/**
+ * Tries to update a branch to a given sha. If the branch doesn't exist, it will be created.
+ *
+ * @param octokit
+ * @param branchName
+ * @param repo
+ * @param owner
+ * @param sha
+ */
+export const updateOrCreateBranch = async (
+  octokit: ProbotOctokit,
+  branchName: string,
+  repo: string,
+  owner: string,
+  sha: string
+) => {
+  try {
+    await octokit.rest.git.updateRef({
+      ref: `heads/${branchName}`,
+      repo,
+      owner,
+      sha,
+      force: true,
+    });
+  } catch {
+    await octokit.rest.git.createRef({
+      ref: `refs/heads/${branchName}`,
+      repo,
+      owner,
+      sha,
+    });
+  }
+};


### PR DESCRIPTION
This PR adds a new feature to the `CopyPRs` plugin, which allows only a single commit to be tested.

If a PR is commented with `test last commit`, then only the most recent commit will be tested in CI (not subsequent commits, as is the case with `okay to test`).