### PR TITLE
Temporarily remove external contributor comment for `rapidsai` org

### DIFF
--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -52,6 +52,12 @@ export class PRCopyPRs {
         return;
       }
 
+      // Temporarily disable comments for the `rapidsai` organization until we're fully migrated
+      // to a new CI setup. This is to avoid confusion with the existing `Can one of the admins verify this patch?`
+      // comment that gets posted as part of our current CI setup.
+      // The skipped test in `test/copy_prs.test.ts` should be un-skipped once this conditional is removed
+      if (orgName === "rapidsai") return;
+
       await this.context.octokit.issues.createComment({
         owner: orgName,
         repo: payload.repository.name,

--- a/test/copy_prs.test.ts
+++ b/test/copy_prs.test.ts
@@ -63,7 +63,9 @@ describe("External Contributors", () => {
     });
   });
 
-  test("pull_request.opened, create correct comment when author is external contibutor", async () => {
+  // This test can be unskipped once the `if (orgName === "rapidsai") return;` statement
+  // is removed from "src/plugins/CopyPRs/pr.ts"
+  test.skip("pull_request.opened, create correct comment when author is external contibutor", async () => {
     const prContext = makePRContext({ action: "opened", user: "ayodes" });
     mockCheckMembershipForUser.mockResolvedValueOnce({ status: 302 });
     mockCreateComment.mockResolvedValueOnce(true);


### PR DESCRIPTION
This PR temporarily skips the external contributor comment that gets posted for the `rapidsai` organization. This is to prevent confusion with the existing `Can one of the admins verify this patch?` comment that gets posted as part of our existing CI setup (like [this](https://github.com/rapidsai/cudf/pull/11164#issuecomment-1168999614)).

Once we're fully migrated away from the existing setup, we should revert this PR.

Also worth noting, the `okay to test` comment will still work for this `ops-bot` plugin, we just won't be posting the external contributor comment for any `rapidsai` organization repositories.