### PR TITLE
Fix Release-Drafter plugin

### DIFF
--- a/src/plugins/ReleaseDrafter/release_drafter.ts
+++ b/src/plugins/ReleaseDrafter/release_drafter.ts
@@ -86,7 +86,8 @@ export class ReleaseDrafter {
   /**
    * Returns true if the branch name is valid. Valid branches should match
    * the branch-yy.mm pattern and have a version that's the same as the repo's
-   * default branch
+   * default branch or branches one or two versions before to account 
+   * for burndown & code-freeze.
    */
   async isValidBranch(): Promise<boolean> {
     if (!isVersionedBranch(this.branchName)) return false;
@@ -94,11 +95,11 @@ export class ReleaseDrafter {
     const defaultBranchVersionNumber = getVersionFromBranch(this.defaultBranch);
 
     if (defaultBranchVersionNumber === branchVersionNumber) return true
-    const { data: json } = await axios.get<{stable: {version}, nightly:{version}, next_nightly:{version}}>(
+    const { data: json } = await axios.get<{legacy: {version}, stable:{version}, nightly:{version}}>(
       `https://raw.githubusercontent.com/rapidsai/docs/gh-pages/_data/releases.json`,
     );
     
-    return [json.stable.version, json.nightly.version, json.next_nightly.version].includes(branchVersionNumber)
+    return [json.stable.version, json.nightly.version, json.legacy.version].includes(branchVersionNumber)
   }
 
   /**

--- a/test/fixtures/contexts/push.ts
+++ b/test/fixtures/contexts/push.ts
@@ -24,7 +24,7 @@ type PushPayload = {
   default_branch?: string;
 };
 
-const makePushContext = ({
+export const makePushContext = ({
   ref = "branch-21.06",
   created = false,
   deleted = false,
@@ -135,18 +135,3 @@ const makePushContext = ({
 
   return (makeContext(payload, "push") as unknown) as PushContext;
 };
-
-export const validDefaultBranch = makePushContext();
-export const validOlderBranch = makePushContext({
-  ref: 'branch-21.04'
-});
-export const validOlderBranch2 = makePushContext({
-  ref: 'branch-21.02'
-});
-export const invalidVersionedBranch = makePushContext({
-  ref: 'branch-0.13',
-  default_branch: 'branch-0.13'
-});
-export const nonVersionedBranch = makePushContext({ ref: "main" });
-export const createdPush = makePushContext({ created: true });
-export const deletedPush = makePushContext({ deleted: true });

--- a/test/fixtures/contexts/push.ts
+++ b/test/fixtures/contexts/push.ts
@@ -136,9 +136,16 @@ const makePushContext = ({
   return (makeContext(payload, "push") as unknown) as PushContext;
 };
 
-export const validBranch = makePushContext();
+export const validDefaultBranch = makePushContext();
+export const validNewerBranch = makePushContext({
+  ref: 'branch-21.08'
+});
+export const validOlderBranch = makePushContext({
+  ref: 'branch-21.04'
+});
 export const invalidVersionedBranch = makePushContext({
-  default_branch: "branch-0.13",
+  ref: 'branch-0.13',
+  default_branch: 'branch-0.13'
 });
 export const nonVersionedBranch = makePushContext({ ref: "main" });
 export const createdPush = makePushContext({ created: true });

--- a/test/fixtures/contexts/push.ts
+++ b/test/fixtures/contexts/push.ts
@@ -137,11 +137,11 @@ const makePushContext = ({
 };
 
 export const validDefaultBranch = makePushContext();
-export const validNewerBranch = makePushContext({
-  ref: 'branch-21.08'
-});
 export const validOlderBranch = makePushContext({
   ref: 'branch-21.04'
+});
+export const validOlderBranch2 = makePushContext({
+  ref: 'branch-21.02'
 });
 export const invalidVersionedBranch = makePushContext({
   ref: 'branch-0.13',

--- a/test/release_drafter.test.ts
+++ b/test/release_drafter.test.ts
@@ -62,7 +62,7 @@ describe("Release Drafter", () => {
   });
 
   test("doesn't run on invalid version branches", async () => {
-    mockedAxios.get.mockResolvedValue({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
+    mockedAxios.get.mockResolvedValue({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, legacy:{version: "21.02"}} });
     await new ReleaseDrafter(context.invalidVersionedBranch).draftRelease();
     expect(mockPaginate).not.toHaveBeenCalled();
     expect(mockGetReleaseByTag).not.toHaveBeenCalled();
@@ -80,11 +80,11 @@ describe("Release Drafter", () => {
   });
 
   test.each([
-    context.validDefaultBranch, context.validNewerBranch, context.validOlderBranch
+    context.validDefaultBranch, context.validOlderBranch, context.validOlderBranch2
   ])("update existing release", async (branch) => {
     mockPaginate.mockResolvedValueOnce(listPullsResp);
     mockGetReleaseByTag.mockResolvedValueOnce(getReleaseByTagResp);
-    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
+    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, legacy:{version: "21.02"}} });
 
     await new ReleaseDrafter(branch).draftRelease();
 
@@ -120,11 +120,11 @@ describe("Release Drafter", () => {
   });
 
   test.each([
-    context.validDefaultBranch, context.validNewerBranch, context.validOlderBranch
+    context.validDefaultBranch, context.validOlderBranch, context.validOlderBranch2
   ])("create new release", async (branch) => {
     mockPaginate.mockResolvedValueOnce(listPullsResp);
     mockGetReleaseByTag.mockRejectedValueOnce("");
-    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
+    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, legacy:{version: "21.02"}} });
 
     await new ReleaseDrafter(branch).draftRelease();
 

--- a/test/release_drafter.test.ts
+++ b/test/release_drafter.test.ts
@@ -29,6 +29,11 @@ import {
 } from "./mocks";
 import { default as repoResp } from "./fixtures/responses/context_repo.json";
 import { makeConfigReponse } from "./fixtures/responses/get_config";
+import axios from "axios";
+import { PushContext } from "../src/types";
+import { getVersionFromBranch } from "../src/shared";
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe("Release Drafter", () => {
   beforeEach(() => {
@@ -37,6 +42,8 @@ describe("Release Drafter", () => {
     mockUpdateRelease.mockReset();
     mockPaginate.mockReset();
     mockListPulls.mockReset();
+    mockedAxios.get.mockReset();
+    jest.resetModules();
   });
 
   beforeAll(() => {
@@ -55,6 +62,7 @@ describe("Release Drafter", () => {
   });
 
   test("doesn't run on invalid version branches", async () => {
+    mockedAxios.get.mockResolvedValue({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
     await new ReleaseDrafter(context.invalidVersionedBranch).draftRelease();
     expect(mockPaginate).not.toHaveBeenCalled();
     expect(mockGetReleaseByTag).not.toHaveBeenCalled();
@@ -71,22 +79,30 @@ describe("Release Drafter", () => {
     expect(mockCreateRelease).not.toHaveBeenCalled();
   });
 
-  test("update existing release", async () => {
+  test.each([
+    context.validDefaultBranch, context.validNewerBranch, context.validOlderBranch
+  ])("update existing release", async (branch) => {
     mockPaginate.mockResolvedValueOnce(listPullsResp);
     mockGetReleaseByTag.mockResolvedValueOnce(getReleaseByTagResp);
-    await new ReleaseDrafter(context.validBranch).draftRelease();
+    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
+
+    await new ReleaseDrafter(branch).draftRelease();
+
+    if(branch != context.validDefaultBranch) {
+      expect(mockedAxios.get).toHaveBeenCalledWith("https://raw.githubusercontent.com/rapidsai/docs/gh-pages/_data/releases.json");
+    }
     expect(mockPaginate).toHaveBeenCalledTimes(1);
     expect(mockPaginate.mock.calls[0][0]).toBe(mockListPulls);
     expect(mockGetReleaseByTag).toHaveBeenCalledTimes(1);
-    expect(mockGetReleaseByTag.mock.calls[0][0].tag).toBe("v21.06.00a");
+    expect(mockGetReleaseByTag.mock.calls[0][0].tag).toBe(`v${getVersionFromBranch(branch.payload.ref)}.00a`);
     expect(mockCreateRelease).not.toHaveBeenCalled();
     expect(mockUpdateRelease.mock.calls[0][0].release_id).toBe(1);
     expect(mockUpdateRelease.mock.calls[0][0].body).toBe(
       `\
 ## 🔗 Links
 
-- [Development Branch](https://github.com/rapidsai/cudf/tree/branch-21.06)
-- [Compare with \`main\` branch](https://github.com/rapidsai/cudf/compare/main...branch-21.06)
+- [Development Branch](https://github.com/rapidsai/cudf/tree/${branch.payload.ref})
+- [Compare with \`main\` branch](https://github.com/rapidsai/cudf/compare/main...${branch.payload.ref})
 
 ## 🚨 Breaking Changes
 
@@ -103,21 +119,29 @@ describe("Release Drafter", () => {
     );
   });
 
-  test("create new release", async () => {
+  test.each([
+    context.validDefaultBranch, context.validNewerBranch, context.validOlderBranch
+  ])("create new release", async (branch) => {
     mockPaginate.mockResolvedValueOnce(listPullsResp);
     mockGetReleaseByTag.mockRejectedValueOnce("");
-    await new ReleaseDrafter(context.validBranch).draftRelease();
+    mockedAxios.get.mockResolvedValueOnce({ data: {stable: {version: "21.04"}, nightly:{version: "21.06"}, next_nightly:{version: "21.08"}} });
+
+    await new ReleaseDrafter(branch).draftRelease();
+
+    if(branch != context.validDefaultBranch) {
+      expect(mockedAxios.get).toHaveBeenCalledWith("https://raw.githubusercontent.com/rapidsai/docs/gh-pages/_data/releases.json");
+    }
     expect(mockPaginate).toHaveBeenCalledTimes(1);
     expect(mockPaginate.mock.calls[0][0]).toBe(mockListPulls);
     expect(mockGetReleaseByTag).toHaveBeenCalledTimes(1);
-    expect(mockGetReleaseByTag.mock.calls[0][0].tag).toBe("v21.06.00a");
+    expect(mockGetReleaseByTag.mock.calls[0][0].tag).toBe(`v${getVersionFromBranch(branch.payload.ref)}.00a`);
     expect(mockUpdateRelease).not.toHaveBeenCalled();
     expect(mockCreateRelease.mock.calls[0][0].body).toBe(
       `\
 ## 🔗 Links
 
-- [Development Branch](https://github.com/rapidsai/cudf/tree/branch-21.06)
-- [Compare with \`main\` branch](https://github.com/rapidsai/cudf/compare/main...branch-21.06)
+- [Development Branch](https://github.com/rapidsai/cudf/tree/${branch.payload.ref})
+- [Compare with \`main\` branch](https://github.com/rapidsai/cudf/compare/main...${branch.payload.ref})
 
 ## 🚨 Breaking Changes
 


### PR DESCRIPTION
This modifies the release drafter plugin to validate branches based on calendar versioning