### PR TITLE
Update `Copy PRs`

### DIFF
--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -24,12 +24,11 @@ import {
 } from "../../types";
 import strip from "strip-comments";
 import {
-  ADMIN_PERMISSION,
   Command,
   featureIsDisabled,
   issueIsPR,
+  Permission,
   validCommentsExistByPredicate,
-  WRITE_PERMISSION,
 } from "../../shared";
 
 export class AutoMerger {
@@ -127,7 +126,7 @@ export class AutoMerger {
       if(!(await validCommentsExistByPredicate(
         this.context,
         pr.number,
-        [ADMIN_PERMISSION, WRITE_PERMISSION],
+        [Permission.admin, Permission.write],
         comment => this.isMergeComment(comment.body || "")))) {
         console.warn(
           `${prDescription} doesn't have merge comment. Skipping...`

--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -23,9 +23,14 @@ import {
   UsersGetByUsernameResponseData,
 } from "../../types";
 import strip from "strip-comments";
-import { ADMIN_PERMISSION, featureIsDisabled, issueIsPR, validCommentsExistByPredicate, WRITE_PERMISSION } from "../../shared";
-
-const MERGE_COMMENT = "@gpucibot merge";
+import {
+  ADMIN_PERMISSION,
+  Command,
+  featureIsDisabled,
+  issueIsPR,
+  validCommentsExistByPredicate,
+  WRITE_PERMISSION,
+} from "../../shared";
 
 export class AutoMerger {
   public context: AutoMergerContext;
@@ -210,11 +215,10 @@ export class AutoMerger {
 
   /**
    * Returns true if the given comment is the merge comment string.
-   * (Case-insensitive, trims leading & trailing whitespace)
    * @param comment
    */
   isMergeComment(comment: string): boolean {
-    return comment.toLowerCase().trim() === MERGE_COMMENT;
+    return Boolean(comment.match(Command.Merge));
   }
 
   /**

--- a/src/plugins/CopyPRs/comment.ts
+++ b/src/plugins/CopyPRs/comment.ts
@@ -15,14 +15,13 @@
  */
 
 import {
-  ADMIN_PERMISSION,
   featureIsDisabled,
   getPRBranchName,
   isOkayToTestComment,
   isOrgMember,
   issueIsPR,
+  Permission,
   updateOrCreateBranch,
-  WRITE_PERMISSION,
 } from "../../shared";
 import { IssueCommentContext } from "../../types";
 
@@ -89,7 +88,7 @@ export class CommentCopyPRs {
   }
 
   private async authorHasPermission(actor) {
-    return [ADMIN_PERMISSION, WRITE_PERMISSION].includes(
+    return [Permission.admin, Permission.write].includes(
       (
         await this.context.octokit.repos.getCollaboratorPermissionLevel({
           owner: this.context.payload.repository.owner.login,

--- a/src/plugins/CopyPRs/comment.ts
+++ b/src/plugins/CopyPRs/comment.ts
@@ -33,14 +33,8 @@ export class CommentCopyPRs {
     const { payload } = this.context;
     const prNumber = payload.issue.number;
     const username = payload.comment.user.login;
-    const testCommitComment = "test last commit";
 
-    if (
-      !(
-        isOkayToTestComment(payload.comment.body) ||
-        payload.comment.body === testCommitComment
-      )
-    ) {
+    if (!isOkayToTestComment(payload.comment.body)) {
       return;
     }
 

--- a/src/plugins/CopyPRs/comment.ts
+++ b/src/plugins/CopyPRs/comment.ts
@@ -38,7 +38,6 @@ export class CommentCopyPRs {
       return;
     }
 
-    //Only run on PRs
     if (!issueIsPR(this.context)) {
       console.warn(
         `Comment on ${payload.repository.full_name} #${prNumber} was not on a PR. Skipping...`
@@ -46,6 +45,8 @@ export class CommentCopyPRs {
       return;
     }
 
+    // branches for org members are created automaticallyin ./pr.ts,
+    // so return here
     if (
       await isOrgMember(
         this.context.octokit,
@@ -56,7 +57,6 @@ export class CommentCopyPRs {
       return;
     }
 
-    //check if comment-er has CI run permission
     if (!(await this.authorHasPermission(username))) {
       console.warn(
         `Comment on ${payload.repository.full_name} #${prNumber} by ${username} does not have trigger permissions. Skipping...`
@@ -64,8 +64,6 @@ export class CommentCopyPRs {
       return;
     }
 
-    // copy code from forked repository to source repository.
-    // first get the PR
     const pr = await this.context.octokit.pulls.get({
       repo: payload.repository.name,
       owner: payload.repository.owner.login,

--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -17,11 +17,8 @@
 import {
   featureIsDisabled,
   getPRBranchName,
-  isOkayToTestComment,
   isOrgMember,
-  Permission,
   updateOrCreateBranch,
-  validCommentsExistByPredicate,
 } from "../../shared";
 import { PRContext } from "../../types";
 
@@ -69,17 +66,11 @@ export class PRCopyPRs {
     // pull_request.synchronize
     if (payload.action === "synchronize" || payload.action === "reopened") {
       if (
-        (await isOrgMember(
+        await isOrgMember(
           this.context.octokit,
           payload.pull_request.user.login,
           orgName
-        )) ||
-        (await validCommentsExistByPredicate(
-          this.context,
-          this.context.payload.pull_request.number,
-          [Permission.admin, Permission.write],
-          (comment) => isOkayToTestComment(comment.body || "") && !!comment.user
-        ))
+        )
       ) {
         await updateOrCreateBranch(
           this.context.octokit,

--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -15,14 +15,13 @@
  */
 
 import {
-  ADMIN_PERMISSION,
   featureIsDisabled,
   getPRBranchName,
   isOkayToTestComment,
   isOrgMember,
+  Permission,
   updateOrCreateBranch,
   validCommentsExistByPredicate,
-  WRITE_PERMISSION,
 } from "../../shared";
 import { PRContext } from "../../types";
 
@@ -78,7 +77,7 @@ export class PRCopyPRs {
         (await validCommentsExistByPredicate(
           this.context,
           this.context.payload.pull_request.number,
-          [ADMIN_PERMISSION, WRITE_PERMISSION],
+          [Permission.admin, Permission.write],
           (comment) => isOkayToTestComment(comment.body || "") && !!comment.user
         ))
       ) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -37,7 +37,7 @@ export const Permission = {
 };
 
 export const Command = {
-  OkToTest: new RegExp("^ok(ay)? to test$"),
+  OkToTest: new RegExp("^/ok(ay)? to test$"),
   Merge: new RegExp("^@gpucibot merge$"),
 };
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -32,10 +32,13 @@ import {
   PullsGetResponseData,
 } from "./types";
 
-const OK_TO_TEST_COMMENT = "ok to test";
-const OKAY_TO_TEST_COMMENT = "okay to test";
 export const ADMIN_PERMISSION = "admin";
 export const WRITE_PERMISSION = "write";
+
+export const Command = {
+  OkToTest: new RegExp("^ok(ay)? to test$"),
+  Merge: new RegExp("^@gpucibot merge$"),
+};
 
 /**
  * RegEx representing RAPIDS branch name patterns
@@ -159,8 +162,8 @@ export const getPRBranchName = (number: number) => {
  * string
  * @param comment
  */
-export const isOkayToTestComment = (comment: string) => {
-  return [OKAY_TO_TEST_COMMENT, OK_TO_TEST_COMMENT].includes(comment);
+export const isOkayToTestComment = (comment: string): Boolean => {
+  return Boolean(comment.match(Command.OkToTest));
 };
 
 /**

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { EmitterWebhookEventName } from "@octokit/webhooks";
 import { Context } from "probot";
 import {
   DefaultOpsBotConfig,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -32,8 +32,10 @@ import {
   PullsGetResponseData,
 } from "./types";
 
-export const ADMIN_PERMISSION = "admin";
-export const WRITE_PERMISSION = "write";
+export const Permission = {
+  admin: "admin",
+  write: "write",
+};
 
 export const Command = {
   OkToTest: new RegExp("^ok(ay)? to test$"),

--- a/test/copy_prs.test.ts
+++ b/test/copy_prs.test.ts
@@ -86,7 +86,7 @@ describe("External Contributors", () => {
     expect(mockCreateRef).toBeCalledTimes(0);
   });
 
-  test.each([["ok to test"], ["okay to test"]])(
+  test.each([["/ok to test"], ["/okay to test"]])(
     "pull_request.synchronize, do nothing when existing okay-to-test comment has insufficient permission",
     async (commentBody) => {
       const prContext = makePRContext({ action: "synchronize", user: "ayode" });
@@ -121,8 +121,8 @@ describe("External Contributors", () => {
   });
 
   test.each([
-    ["ok to test", "admin"],
-    ["okay to test", "write"],
+    ["/ok to test", "admin"],
+    ["/okay to test", "write"],
   ])(
     "pull_request.synchronize, when valid existing okay-to-test comment, update commit in source repo for external contributor",
     async (commentBody, permission) => {
@@ -180,7 +180,7 @@ describe("External Contributors", () => {
     expect(mockUpdateRef).toBeCalledTimes(0);
   });
 
-  test.each([["ok to test"], ["okay to test"]])(
+  test.each([["/ok to test"], ["/okay to test"]])(
     "pull_request.reopened, do nothing when existing okay-to-test comment has insufficient permission for external contributor",
     async (commentBody) => {
       const prContext = makePRContext({ action: "reopened", user: "ayode" });
@@ -209,8 +209,8 @@ describe("External Contributors", () => {
   );
 
   test.each([
-    ["ok to test", "admin"],
-    ["okay to test", "write"],
+    ["/ok to test", "admin"],
+    ["/okay to test", "write"],
   ])(
     "pull_request.reopened, when valid existing okay-to-test comment, update commit in source repo for external contributors",
     async (commentBody, permission) => {
@@ -239,8 +239,8 @@ describe("External Contributors", () => {
   );
 
   test.each([
-    ["ok to test", "admin"],
-    ["okay to test", "write"],
+    ["/ok to test", "admin"],
+    ["/okay to test", "write"],
   ])(
     "pull_request.reopened, when valid existing okay-to-test comment and branch is deleted, re-create branch in source repo",
     async (commentBody, permission) => {
@@ -300,7 +300,7 @@ describe("External Contributors", () => {
     expect(mockCheckMembershipForUser).toHaveBeenCalledTimes(0);
   });
 
-  test.each([["ok to test"], ["okay to test"]])(
+  test.each([["/ok to test"], ["/okay to test"]])(
     "issue_comment.created, do nothing if issue is not PR",
     async (body) => {
       const issueContext = makeIssueCommentContext({ is_pr: false, body });
@@ -311,7 +311,7 @@ describe("External Contributors", () => {
     }
   );
 
-  test.each([["ok to test"], ["okay to test"]])(
+  test.each([["/ok to test"], ["/okay to test"]])(
     "issue_comment.created, do nothing if issue author is org member",
     async (body) => {
       const issueContext = makeIssueCommentContext({ is_pr: true, body });
@@ -323,7 +323,7 @@ describe("External Contributors", () => {
     }
   );
 
-  test.each([["ok to test"], ["okay to test"]])(
+  test.each([["/ok to test"], ["/okay to test"]])(
     "issue_comment.created, if commenter has insufficient permissions",
     async (body) => {
       const issueContext = makeIssueCommentContext({ is_pr: true, body });
@@ -343,8 +343,8 @@ describe("External Contributors", () => {
   );
 
   test.each([
-    ["ok to test", "admin"],
-    ["okay to test", "write"],
+    ["/ok to test", "admin"],
+    ["/okay to test", "write"],
     ["test last commit", "admin"],
     ["test last commit", "write"],
   ])(
@@ -376,8 +376,8 @@ describe("External Contributors", () => {
   );
 
   test.each([
-    ["ok to test", "admin"],
-    ["okay to test", "write"],
+    ["/ok to test", "admin"],
+    ["/okay to test", "write"],
     ["test last commit", "admin"],
     ["test last commit", "write"],
   ])(

--- a/test/fixtures/responses/list_comments.json
+++ b/test/fixtures/responses/list_comments.json
@@ -51,6 +51,6 @@
     },
     "created_at": "2020-12-01T20:11:04Z",
     "updated_at": "2020-12-01T20:11:04Z",
-    "body": "@gpucibot Merge "
+    "body": "@gpucibot merge"
   }
 ]

--- a/test/release_drafter.test.ts
+++ b/test/release_drafter.test.ts
@@ -15,7 +15,6 @@
 */
 
 import { ReleaseDrafter } from "../src/plugins/ReleaseDrafter/release_drafter";
-import * as context from "./fixtures/contexts/push";
 import { release_drafter as listPullsResp } from "./fixtures/responses/list_pulls.json";
 import { default as getReleaseByTagResp } from "./fixtures/responses/get_release_by_tag.json";
 import {
@@ -30,7 +29,6 @@ import {
 import { default as repoResp } from "./fixtures/responses/context_repo.json";
 import { makeConfigReponse } from "./fixtures/responses/get_config";
 import axios from "axios";
-import { PushContext } from "../src/types";
 import { getVersionFromBranch } from "../src/shared";
 import { makePushContext } from "./fixtures/contexts/push";
 jest.mock("axios");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedLocals": true /* Report errors on unused locals. */,
     // "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,


### PR DESCRIPTION
The PR adjusts the `Copy PRs` plugin according to the implementation details below:

- current implementation:
  - `okay to test` - tests last commit and all subsequent commits
  - `test last commit` - tests last commit, but not subsequent commits
- new implementation:
  - `/okay to test` - tests last commit, but not subsequent commits
  - `okay to test` - this command was removed in favor of `/okay to test`
  - `test last commit` - this command was removed

This ensures that all commits must be validated by an organization member with `write` or `admin` permissions before CI will run on any given PR.

I will open a subsequent PR to add an "allow list" of users whose PR commits will automatically be tested under the condition that the commits are signed and verified by GitHub.