### PR TITLE
Change `rerun tests` cmd to `/rerun tests`

### DIFF
--- a/src/plugins/RerunTests/rerun_tests.ts
+++ b/src/plugins/RerunTests/rerun_tests.ts
@@ -15,7 +15,7 @@
  */
 
 import axios from "axios";
-import { featureIsDisabled, getPRBranchName, issueIsPR } from "../../shared";
+import { Command, featureIsDisabled, getPRBranchName, issueIsPR } from "../../shared";
 import { IssueCommentContext } from "../../types";
 
 export class RerunTests {
@@ -31,7 +31,7 @@ export class RerunTests {
     if (await featureIsDisabled(context, "rerun_tests")) return;
 
     if (!issueIsPR(context)) return;
-    if (!context.payload.comment.body.match(/.*(re)?run\W+tests.*/)) return;
+    if (!context.payload.comment.body.match(Command.RerunTests)) return;
 
     const repo = context.payload.repository.name;
     const prNumber = context.payload.issue.number;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -38,6 +38,7 @@ export const Permission = {
 
 export const Command = {
   OkToTest: new RegExp("^/ok(ay)? to test$"),
+  RerunTests: new RegExp("^/rerun tests$"),
   Merge: new RegExp("^@gpucibot merge$"),
 };
 

--- a/test/rerun_tests.test.ts
+++ b/test/rerun_tests.test.ts
@@ -77,11 +77,11 @@ describe("Rerun Tests", () => {
       false,
       "https://gpuci.gpuopenanalytics.com/job/orgs/job/cudf/job/pull-request%2F468/build",
     ],
-  ])("PR comment is rerun tests", async (isPrivateRepo, expectedPostUrl) => {
+  ])("PR comment is /rerun tests", async (isPrivateRepo, expectedPostUrl) => {
     const context = makeIssueCommentContext({
       is_pr: true,
       is_private: isPrivateRepo,
-      body: "rerun tests",
+      body: "/rerun tests",
     });
     mockedAxios.get.mockResolvedValueOnce({ data: "Jenkins-Crumb:abc1234" });
     process.env.JENKINS_USERNAME = "jenkinsuser";


### PR DESCRIPTION
This PR changes the `rerun tests` command to `/rerun tests`.

Note, that the functionality of this plugin is currently only used by the morpheus organization.