### PR TITLE
Disable `Copy PRs` & Make checks successful for `GPUTester` PRs

### DIFF
--- a/src/plugins/BranchChecker/check_pr.ts
+++ b/src/plugins/BranchChecker/check_pr.ts
@@ -1,22 +1,22 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import {
   createSetCommitStatus,
-  isReleasePR,
+  isGPUTesterPR,
   isVersionedBranch,
   getVersionFromBranch,
 } from "../../shared";
@@ -43,8 +43,8 @@ export const checkPR = async (
 
   await setCommitStatus("Checking base branch...", "pending");
 
-  if (isReleasePR(pr)) {
-    return await setCommitStatus("Release PR detected", "success");
+  if (isGPUTesterPR(pr)) {
+    return await setCommitStatus("Automated GPUTester PR detected", "success");
   }
 
   if (!isVersionedBranch(prBaseBranch)) {

--- a/src/plugins/CopyPRs/pr.ts
+++ b/src/plugins/CopyPRs/pr.ts
@@ -17,6 +17,7 @@
 import {
   featureIsDisabled,
   getPRBranchName,
+  isGPUTesterPR,
   isOrgMember,
   updateOrCreateBranch,
 } from "../../shared";
@@ -29,6 +30,10 @@ export class PRCopyPRs {
     const { payload } = this.context;
     const orgName = payload.repository.owner.login;
     if (await featureIsDisabled(this.context, "copy_prs")) return;
+
+    if (isGPUTesterPR(payload.pull_request)) {
+      return;
+    }
 
     // pull_request.opened event
     if (payload.action === "opened") {

--- a/src/plugins/LabelChecker/label_checker.ts
+++ b/src/plugins/LabelChecker/label_checker.ts
@@ -1,23 +1,23 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import {
   createSetCommitStatus,
   featureIsDisabled,
-  isReleasePR,
+  isGPUTesterPR,
 } from "../../shared";
 import { PRContext } from "../../types";
 
@@ -53,16 +53,9 @@ export class LabelChecker {
       await new Promise((res) => setTimeout(res, 2000));
     }
 
-    if (this.isForwardMergePR()) {
+    if (isGPUTesterPR(context.payload.pull_request)) {
       return await setCommitStatus(
-        "No labels necessary for forward-merging PRs",
-        "success"
-      );
-    }
-
-    if (isReleasePR(context.payload.pull_request)) {
-      return await setCommitStatus(
-        "No labels necessary for release PRs",
+        "No labels necessary for GPUTester PRs",
         "success"
       );
     }
@@ -145,15 +138,5 @@ export class LabelChecker {
     }
 
     return await setCommitStatus("Correct labels applied", "success");
-  }
-
-  private isForwardMergePR(): boolean {
-    const { context } = this;
-    return (
-      context.payload.pull_request.user.login === "GPUtester" &&
-      context.payload.pull_request.title
-        .toLowerCase()
-        .includes("[gpuci] forward-merge")
-    );
   }
 }

--- a/src/plugins/RecentlyUpdated/check_pr.ts
+++ b/src/plugins/RecentlyUpdated/check_pr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createSetCommitStatus, isReleasePR } from "../../shared";
+import { createSetCommitStatus, isGPUTesterPR } from "../../shared";
 import { PRContext, ProbotOctokit, PullsListResponseData } from "../../types";
 
 export const checkPR = async (
@@ -36,8 +36,8 @@ export const checkPR = async (
 
   await setCommitStatus("Checking if PR has recent updates...", "pending");
 
-  if (isReleasePR(pr)) {
-    await setCommitStatus("Release PR detected", "success");
+  if (isGPUTesterPR(pr)) {
+    await setCommitStatus("Automated GPUTester PR detected", "success");
     return;
   }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -93,13 +93,10 @@ export const createSetCommitStatus = (
   };
 };
 
-export const isReleasePR = (
-  pullRequest: Pick<PullsGetResponseData, "title" | "user">
+export const isGPUTesterPR = (
+  pullRequest: Pick<PullsGetResponseData, "user">
 ): boolean => {
-  return (
-    pullRequest.user?.login === "GPUtester" &&
-    pullRequest.title.toLowerCase().includes("[release]")
-  );
+  return pullRequest.user?.login.toLowerCase() === "gputester";
 };
 
 /**

--- a/test/branch_checker.test.ts
+++ b/test/branch_checker.test.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { PRBranchChecker } from "../src/plugins/BranchChecker/pull_request";
 import { RepositoryBranchChecker } from "../src/plugins/BranchChecker/repository";
@@ -59,7 +59,7 @@ describe("Label Checker", () => {
       expect(mockCreateCommitStatus.mock.calls[0][0].state).toBe("pending");
       expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Release PR detected"
+        "Automated GPUTester PR detected"
       );
     });
 
@@ -168,7 +168,7 @@ describe("Label Checker", () => {
       expect(mockCreateCommitStatus.mock.calls[0][0].state).toBe("pending");
       expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Release PR detected"
+        "Automated GPUTester PR detected"
       );
     });
   });

--- a/test/label_checker.test.ts
+++ b/test/label_checker.test.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { LabelChecker } from "../src/plugins/LabelChecker/label_checker";
 import { makePRContext } from "./fixtures/contexts/pull_request";
@@ -232,7 +232,7 @@ describe("Label Checker", () => {
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
     expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-      "No labels necessary for forward-merging PRs"
+      "No labels necessary for GPUTester PRs"
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].target_url).toBe(
       "https://docs.rapids.ai/resources/label-checker/"
@@ -255,7 +255,7 @@ describe("Label Checker", () => {
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
     expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-      "No labels necessary for release PRs"
+      "No labels necessary for GPUTester PRs"
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].target_url).toBe(
       "https://docs.rapids.ai/resources/label-checker/"

--- a/test/label_checker.test.ts
+++ b/test/label_checker.test.ts
@@ -216,32 +216,9 @@ describe("Label Checker", () => {
     );
   });
 
-  test("correct labels - forward merge PR", async () => {
+  test("correct labels - GPUTester PR", async () => {
     const context = makePRContext({
       title: "[gpuCI] Forward-merge branch-0.18 to branch-0.19 [skip ci]",
-      user: "GPUtester",
-    });
-    await new LabelChecker(context).checkLabels();
-    expect(mockCreateCommitStatus).toBeCalledTimes(2);
-    expect(mockCreateCommitStatus.mock.calls[0][0].state).toBe("pending");
-    expect(mockCreateCommitStatus.mock.calls[0][0].target_url).toBe(
-      "https://docs.rapids.ai/resources/label-checker/"
-    );
-    expect(mockCreateCommitStatus.mock.calls[0][0].description).toBe(
-      "Checking labels..."
-    );
-    expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
-    expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-      "No labels necessary for GPUTester PRs"
-    );
-    expect(mockCreateCommitStatus.mock.calls[1][0].target_url).toBe(
-      "https://docs.rapids.ai/resources/label-checker/"
-    );
-  });
-
-  test("correct labels - release PR", async () => {
-    const context = makePRContext({
-      title: "[RELEASE] cuml v0.18",
       user: "GPUtester",
     });
     await new LabelChecker(context).checkLabels();

--- a/test/recently_updated.test.ts
+++ b/test/recently_updated.test.ts
@@ -58,7 +58,7 @@ describe("Recently Updated", () => {
       expect(mockCreateCommitStatus.mock.calls[0][0].state).toBe("pending");
       expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Release PR detected"
+        "Automated GPUTester PR detected"
       );
     });
 
@@ -112,7 +112,7 @@ describe("Recently Updated", () => {
       expect(mockCreateCommitStatus.mock.calls[0][0].state).toBe("pending");
       expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Release PR detected"
+        "Automated GPUTester PR detected"
       );
     });
 


### PR DESCRIPTION
This PR updates some logic to ensure that statuses set on `GPUTester` PRs are always successful.

Additionally, it ensures that any PRs opened by `GPUTester` aren't copied to a `pull-request/*` branch for testing. This has adverse affects for GitHub Actions with the forward-merging PRs.