### PR TITLE
Add `check_suite` support for Auto Merger

### DIFF
--- a/src/plugins/AutoMerger/index.ts
+++ b/src/plugins/AutoMerger/index.ts
@@ -1,25 +1,30 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { Probot } from "probot";
 import { AutoMerger } from "./auto_merger";
 
 export const initAutoMerger = (app: Probot) => {
   app.on(
-    ["issue_comment.created", "pull_request_review.submitted", "status"],
+    [
+      "issue_comment.created",
+      "pull_request_review.submitted",
+      "status",
+      "check_suite.completed",
+    ],
     async (context) => {
       await new AutoMerger(context).maybeMergePR();
     }

--- a/src/plugins/AutoMerger/resolve_prs.ts
+++ b/src/plugins/AutoMerger/resolve_prs.ts
@@ -2,6 +2,7 @@ import { Logger } from "probot";
 import { issueIsPR, isMergeComment } from "../../shared";
 import {
   AutoMergerContext,
+  CheckSuiteContext,
   IssueCommentContext,
   PRReviewContext,
   StatusContext,
@@ -25,6 +26,8 @@ export class PRNumberResolver {
         return this.issueCommentContextHandler(context);
       case "pull_request_review":
         return this.pullRequestReviewContextHandler(context);
+      case "check_suite":
+        return this.checkSuiteContextHandler(context);
       default:
         return [];
     }
@@ -36,6 +39,16 @@ export class PRNumberResolver {
       return [];
     }
     return this.getPRNumbersfromSHA(context.payload.sha);
+  }
+
+  async checkSuiteContextHandler(
+    context: CheckSuiteContext
+  ): Promise<number[]> {
+    if (context.payload.check_suite.conclusion !== "success") {
+      this.logger.info("check suite was not success");
+      return [];
+    }
+    return this.getPRNumbersfromSHA(context.payload.check_suite.head_sha);
   }
 
   issueCommentContextHandler(context: IssueCommentContext): number[] {

--- a/src/plugins/AutoMerger/resolve_prs.ts
+++ b/src/plugins/AutoMerger/resolve_prs.ts
@@ -1,0 +1,79 @@
+import { Logger } from "probot";
+import { issueIsPR, isMergeComment } from "../../shared";
+import {
+  AutoMergerContext,
+  IssueCommentContext,
+  PRReviewContext,
+  StatusContext,
+} from "../../types";
+
+export class PRNumberResolver {
+  public context: AutoMergerContext;
+  public logger: Logger;
+
+  constructor(context: AutoMergerContext, logger: Logger) {
+    this.context = context;
+    this.logger = logger;
+  }
+  async getPrNumbers(): Promise<number[]> {
+    const { context } = this;
+
+    switch (context.name) {
+      case "status":
+        return this.statusContextHandler(context);
+      case "issue_comment":
+        return this.issueCommentContextHandler(context);
+      case "pull_request_review":
+        return this.pullRequestReviewContextHandler(context);
+      default:
+        return [];
+    }
+  }
+
+  async statusContextHandler(context: StatusContext): Promise<number[]> {
+    if (context.payload.state !== "success") {
+      this.logger.info("status was not success");
+      return [];
+    }
+    return this.getPRNumbersfromSHA(context.payload.sha);
+  }
+
+  issueCommentContextHandler(context: IssueCommentContext): number[] {
+    const comment = context.payload.comment.body;
+    if (!issueIsPR(context)) {
+      this.logger.info("comment was for issue, not PR");
+      return [];
+    }
+    if (!isMergeComment(comment)) {
+      this.logger.info("not a merge comment");
+      return [];
+    }
+    return [context.payload.issue.number];
+  }
+
+  pullRequestReviewContextHandler(context: PRReviewContext): number[] {
+    if (context.payload.review.state !== "approved") {
+      this.logger.info("PR review was not approval");
+      return [];
+    }
+    return [context.payload.pull_request.number];
+  }
+
+  /**
+   * Returns open pull requests that contain SHA from webhook payload.
+   * @param context
+   */
+  async getPRNumbersfromSHA(sha: string): Promise<number[]> {
+    const { context } = this;
+    const repoName = context.payload.repository.full_name;
+
+    const { data: prs } = await context.octokit.search.issuesAndPullRequests({
+      q: `${sha}+is:pr+is:open+repo:${repoName}`,
+      per_page: 100,
+    });
+
+    const prNumbers = prs.items.map((el) => el.number);
+    this.logger.info({ prs: prNumbers }, "PRs associated with commit");
+    return prNumbers;
+  }
+}

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -120,6 +120,14 @@ export const isOkayToTestComment = (comment: string): Boolean => {
 };
 
 /**
+ * Returns true if the given comment is the merge comment string.
+ * @param comment
+ */
+export const isMergeComment = (comment: string): boolean => {
+  return Boolean(comment.match(Command.Merge));
+};
+
+/**
  * Retrieves the issue/PR comments that fit provided criteria
  * @param context
  * @param prNumber

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) 2022, NVIDIA CORPORATION.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import { Context } from "probot";
 import { Repository } from "@octokit/webhooks-types";
@@ -30,9 +30,10 @@ export type PushContext = ContextFactory<"push">;
 export type IssueCommentContext = ContextFactory<"issue_comment">;
 export type PRReviewContext = ContextFactory<"pull_request_review">;
 export type StatusContext = ContextFactory<"status">;
+export type CheckSuiteContext = ContextFactory<"check_suite">;
 export type RepositoryContext = ContextFactory<"repository">;
 export type AutoMergerContext = ContextFactory<
-  "issue_comment" | "pull_request_review" | "status"
+  "issue_comment" | "pull_request_review" | "status" | "check_suite"
 >;
 export type PullsGetResponseData =
   RestEndpointMethodTypes["pulls"]["get"]["response"]["data"];
@@ -42,7 +43,8 @@ export type UsersGetByUsernameResponseData =
   RestEndpointMethodTypes["users"]["getByUsername"]["response"]["data"];
 export type ReposListCommitStatusesForRefResponseData =
   RestEndpointMethodTypes["repos"]["listCommitStatusesForRef"]["response"]["data"];
-export type IssuesCommentsResponseData = RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"]
+export type IssuesCommentsResponseData =
+  RestEndpointMethodTypes["issues"]["listComments"]["response"]["data"];
 export type PayloadRepository = Repository;
 export type ProbotOctokit = Context["octokit"];
 


### PR DESCRIPTION
This PR includes the following changes:

- refactors the `auto_merger` plugin
- adds `check_suite` event support for the `auto_merge`

`check_suite` event support is necessary in order for the `auto_merger` plugin to allow for queuing PRs to be merged with GitHub Actions.

This is because GitHub Actions uses the [Checks API](https://docs.github.com/en/rest/checks) to deliver CI results to commits rather than a conventional commit status.