### PR TITLE
Change merge comment to `/merge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugins are listed in the [src/plugins](./src/plugins) folder.
   - `bug`, `doc`, `feature request`, or `improvement`
   - `breaking` or `non-breaking`
 - **Release Drafter** - Opens up a draft release on GitHub anytime a PR is merged to a versioned branch (i.e. `branch-0.17`, `branch-0.18`, etc.). The draft body includes a categorized changelog consisting of the PRs that have been merged on that branch.
-- **Auto Merger** - Automatically merges PRs that include the `@gpucibot merge` comment and meet the merge criteria outlined in [https://docs.rapids.ai/resources/auto-merger/](https://docs.rapids.ai/resources/auto-merger/).
+- **Auto Merger** - Automatically merges PRs that include the `/merge` comment and meet the merge criteria outlined in [https://docs.rapids.ai/resources/auto-merger/](https://docs.rapids.ai/resources/auto-merger/).
 - **Branch Checker** - Set a status on PRs that checks whether they are targeting either the repo's _default branch_ or _default branch + 1_
 - **Copy PRs** - Copies pull request branches from their forked repository to the source repository for testing. If a pull request is from a GitHub author that is not a member of the GitHub organization, it will require an `okay to test` comment be submitted to the PR by a member of the GitHub organization before the forked code is copied to the source repository. Every new commit from external contributor PRs will also require an `okay to test` command. `ok to test` may also be used.
 - **Rerun Tests** - Listens for comments on PRs and runs a new Jenkins build if the comment matches a particular regular expression.

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -32,7 +32,7 @@ export const Permission = {
 export const Command = {
   OkToTest: new RegExp("^/ok(ay)? to test$"),
   RerunTests: new RegExp("^/rerun tests$"),
-  Merge: new RegExp("^@gpucibot merge$"),
+  Merge: new RegExp("^/merge$"),
 };
 
 /**

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -33,6 +33,7 @@ export const Command = {
   OkToTest: new RegExp("^/ok(ay)? to test$"),
   RerunTests: new RegExp("^/rerun tests$"),
   Merge: new RegExp("^/merge$"),
+  OldMerge: new RegExp("^@gpucibot merge$"),
 };
 
 /**
@@ -125,6 +126,14 @@ export const isOkayToTestComment = (comment: string): Boolean => {
  */
 export const isMergeComment = (comment: string): boolean => {
   return Boolean(comment.match(Command.Merge));
+};
+
+/**
+ * Returns true if the given comment is the old merge comment string.
+ * @param comment
+ */
+export const isOldMergeComment = (comment: string): boolean => {
+  return Boolean(comment.match(Command.OldMerge));
 };
 
 /**

--- a/test/fixtures/responses/list_comments.json
+++ b/test/fixtures/responses/list_comments.json
@@ -51,6 +51,6 @@
     },
     "created_at": "2020-12-01T20:11:04Z",
     "updated_at": "2020-12-01T20:11:04Z",
-    "body": "@gpucibot merge"
+    "body": "/merge"
   }
 ]


### PR DESCRIPTION
This PR changes the comment required to trigger the auto-merger from `@gpucibot merge` to `/merge`.

It also adds functionality to comment the following message on a PR if someone tries to use `@gpucibot merge`:


```
@<author>, the `@gpucibot merge` command has been replaced with `/merge`.

Please re-comment this PR with `/merge` and use this new command in the future.
```


I'll remove the comment functionality in a few weeks once everyone is accustomed to the change.