### PR TITLE
Update `CopyPRs` plugin to account for trusted external collaborators

### DIFF
--- a/src/plugins/CopyPRs/comment.ts
+++ b/src/plugins/CopyPRs/comment.ts
@@ -18,7 +18,7 @@ import { OpsBotPlugin } from "../../plugin";
 import {
   getPRBranchName,
   isOkayToTestComment,
-  isOrgMember,
+  isTrustedUser,
   issueIsPR,
   Permission,
   updateOrCreateBranch,
@@ -47,13 +47,14 @@ export class CommentCopyPRs extends OpsBotPlugin {
       return;
     }
 
-    // branches for org members are created automaticallyin ./pr.ts,
+    // branches for org members/external collaborators are created automaticallyin ./pr.ts,
     // so return here
     if (
-      await isOrgMember(
+      await isTrustedUser(
         this.context.octokit,
         payload.issue.user.login,
-        payload.repository.owner.login
+        payload.repository.owner.login,
+        payload.repository.name
       )
     ) {
       return;

--- a/test/copy_prs.test.ts
+++ b/test/copy_prs.test.ts
@@ -163,12 +163,18 @@ describe("Copy PRs", () => {
     "issue_comment.created, if commenter has insufficient permissions",
     async (body) => {
       const issueContext = makeIssueCommentContext({ is_pr: true, body });
-      mockGetUserPermissionLevel.mockResolvedValueOnce({
-        data: { permission: "non-admin" },
-      });
       mockCheckMembershipForUser.mockResolvedValueOnce({ status: 302 });
+      mockGetUserPermissionLevel.mockResolvedValueOnce({
+        data: { permission: "read" },
+      }); // mocks isTrustedExternalCollaborator
+      mockGetUserPermissionLevel.mockResolvedValueOnce({
+        data: { permission: "read" },
+      }); // mocks authorHasPermission
       await new CommentCopyPRs(issueContext).maybeCopyPR();
 
+      expect(mockUpdateRef).toBeCalledTimes(0);
+      expect(mockCreateRef).toBeCalledTimes(0);
+      expect(mockCreateComment).toBeCalledTimes(0);
       expect(mockCheckMembershipForUser).toHaveBeenCalledTimes(1);
       expect(mockGetUserPermissionLevel).toHaveBeenCalledWith({
         owner: issueContext.payload.repository.owner.login,
@@ -186,8 +192,11 @@ describe("Copy PRs", () => {
     async (body, permission) => {
       const issueContext = makeIssueCommentContext({ is_pr: true, body });
       mockGetUserPermissionLevel.mockResolvedValueOnce({
+        data: { permission: "read" },
+      }); // mocks isTrustedExternalCollaborator
+      mockGetUserPermissionLevel.mockResolvedValueOnce({
         data: { permission },
-      });
+      }); // mocks authorHasPermission
       mockPullsGet.mockResolvedValueOnce({
         data: { head: { sha: "sha1234" } },
       });
@@ -217,8 +226,11 @@ describe("Copy PRs", () => {
     async (body, permission) => {
       const issueContext = makeIssueCommentContext({ is_pr: true, body });
       mockGetUserPermissionLevel.mockResolvedValueOnce({
+        data: { permission: "read" },
+      }); // mocks isTrustedExternalCollaborator
+      mockGetUserPermissionLevel.mockResolvedValueOnce({
         data: { permission },
-      });
+      }); // mocks authorHasPermission
       mockPullsGet.mockResolvedValueOnce({
         data: { head: { sha: "sha1234" } },
       });


### PR DESCRIPTION
This PR updates the `CopyPRs` plugin to account for external collaborators.

Before this PR, users that were external collaborators for a particular repository did not have their PRs copied to the source repository for automatic testing even if they had `write` or `admin` permissions on that repository.

This PR fixes that.

Closes #134.