### PR TITLE
Use OIDC to get AWS credentials in CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,12 +14,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: Deploy Probot Application
     runs-on: ubuntu-latest
     container: node:18
     steps:
+      - name: Get AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ vars.SERVERLESS_AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install npm dependencies
@@ -35,8 +44,6 @@ jobs:
       - name: Deploy Probot
         run: npm run deploy
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }}
           APP_ID: ${{ secrets.APP_ID }}
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -1,4 +1,4 @@
-service: gpuci-serverless-ops-bot-probot
+service: ops-bot
 
 provider:
   name: aws
@@ -10,7 +10,7 @@ provider:
   apiGateway:
     shouldStartNameWithService: true
   deploymentBucket:
-    name: rapids-serverless-deployments
+    name: rapidsai-serverless-deployments
   environment:
     NODE_ENV: production
     LOG_FORMAT: json


### PR DESCRIPTION
Use OIDC to get AWS credentials in CI. We also need to rename the stack from `gpuci-` to `rapidsai-` as the OIDC credentials policy is using this new prefix