### PR TITLE
Remove PR/commit title sanitization functions

### DIFF
--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -79,7 +79,7 @@ export class AutoMerger extends OpsBotPlugin {
 
       // Merge PR
       this.logger.info({ pr }, "merging PR");
-      const commitTitle = this.sanitizePrTitle(pr.title) + ` (#${pr.number})`;
+      const commitTitle = `${pr.title.trim()} (#${pr.number})`;
       await context.octokit.pulls.merge({
         owner: repo.owner.login,
         repo: repo.name,
@@ -242,13 +242,5 @@ export class AutoMerger extends OpsBotPlugin {
           ).data
       )
     );
-  }
-
-  /**
-   * Removes square brackets, [], and their contents from a given string
-   * @param rawTitle
-   */
-  sanitizePrTitle(rawTitle): string {
-    return rawTitle.replace(/\[[\s\S]*?\]/g, "").trim();
   }
 }

--- a/src/plugins/ReleaseDrafter/draft_template.njk
+++ b/src/plugins/ReleaseDrafter/draft_template.njk
@@ -1,5 +1,5 @@
 {% macro prEntry(pr) %}
-- {{ pr.title | sanitizeTitle }} (#{{ pr.number }}) @{{ pr.user.login }}
+- {{ pr.title | trim }} (#{{ pr.number }}) @{{ pr.user.login }}
 {%- endmacro %}
 
 ## 🔗 Links

--- a/src/plugins/ReleaseDrafter/release_drafter.ts
+++ b/src/plugins/ReleaseDrafter/release_drafter.ts
@@ -166,11 +166,6 @@ export class ReleaseDrafter extends OpsBotPlugin {
       lstripBlocks: true,
     });
 
-    // Remove square brackets from title
-    nj.addFilter("sanitizeTitle", (title) =>
-      title.replace(/\[[\s\S]*?\]/g, "").trim()
-    );
-
     return nj
       .renderString(templateStr, {
         categories,

--- a/test/auto_merger.test.ts
+++ b/test/auto_merger.test.ts
@@ -77,7 +77,7 @@ describe("Auto Merger", () => {
       repo: "cudf",
       pull_number: 1234,
       merge_method: "squash",
-      commit_title: "Implement cudf.DateOffset for months (#1234)",
+      commit_title: "[REVIEW] Implement cudf.DateOffset for months (#1234)",
       commit_message: `Implements \`cudf.DateOffset\` - an object used for calendrical arithmetic, similar to pandas.DateOffset - for month units only.
 
 Closes https://github.com/rapidsai/cudf/issues/6754
@@ -128,7 +128,7 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
       repo: "cudf",
       pull_number: 1234,
       merge_method: "squash",
-      commit_title: "Implement cudf.DateOffset for months (#1234)",
+      commit_title: "[REVIEW] Implement cudf.DateOffset for months (#1234)",
       commit_message:
         expected_body +
         `

--- a/test/release_drafter.test.ts
+++ b/test/release_drafter.test.ts
@@ -114,11 +114,11 @@ describe("Release Drafter", () => {
 
 ## 🚨 Breaking Changes
 
-- Some PR title (#1234) @octokit
+- [WIP] [skip-ci] Some PR title (#1234) @octokit
 
 ## 🐛 Bug Fixes
 
-- Some PR title (#1234) @octokit
+- [WIP] [skip-ci] Some PR title (#1234) @octokit
 
 ## 📖 Documentation
 
@@ -159,11 +159,11 @@ describe("Release Drafter", () => {
 
 ## 🚨 Breaking Changes
 
-- Some PR title (#1234) @octokit
+- [WIP] [skip-ci] Some PR title (#1234) @octokit
 
 ## 🐛 Bug Fixes
 
-- Some PR title (#1234) @octokit
+- [WIP] [skip-ci] Some PR title (#1234) @octokit
 
 ## 📖 Documentation
 


### PR DESCRIPTION
This PR removes the sanitization functions that removed square brackets (`[]`) and their contents from PR titles for commit messages and release notes.

The tests were also updated.