### PR TITLE
Add retries to commit status API requests

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -83,6 +83,10 @@ export const createSetCommitStatus = (
       state,
       description,
       target_url,
+      request: {
+        retries: 3,
+        retryAfter: 10,
+      },
     });
   };
 };


### PR DESCRIPTION
Recently we've been seeing some `422` error codes returned for our HTTP requests to the [_Create a commit status_](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status) endpoint.

The associated error message indicates that we've hit a limit on the statuses for a particular SHA in a given repository.

After analyzing the logs, it doesn't appear that we're _actually_ reaching the limits described by the endpoint.

Therefore we've concluded that it could be an issue on GitHub's end that can be resolved by simply retrying the requests.

This PR adds a retry configuration for our `createCommitStatus` calls.

It will retry 3 times, waiting 10 seconds between each retry.

This retry configuration is described here: https://github.com/octokit/plugin-retry.js/blob/main/README.md?plain=1#L79