### PR TITLE
Fix bad committer user information

### DIFF
--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -238,15 +238,17 @@ export class AutoMerger extends OpsBotPlugin {
       uniqueApprovers.push(approvalAuthor);
     }
 
-    return Promise.all(
-      uniqueApprovers.map(
-        async (approver) =>
-          (
-            await octokit.users.getByUsername({
-              username: approver,
-            })
-          ).data
+    return (
+      await Promise.all(
+        uniqueApprovers.map(async (approver) => {
+          try {
+            return (await octokit.users.getByUsername({ username: approver }))
+              .data;
+          } catch (error) {
+            return null;
+          }
+        })
       )
-    );
+    ).filter((x): x is UsersGetByUsernameResponseData => Boolean(x));
   }
 }

--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -141,7 +141,7 @@ export class AutoMerger extends OpsBotPlugin {
       preserveNewlines: false,
     }).trim();
 
-    const authors = await this.getAuthors(pr);
+    const authors = (await this.getAuthors(pr)).filter(author => !!author);
     const approvers = await this.getApprovers(pr);
     const formatUserName = (user: UsersGetByUsernameResponseData): string => {
       if (user.name) {
@@ -200,10 +200,13 @@ export class AutoMerger extends OpsBotPlugin {
     }
 
     return Promise.all(
-      uniqueAuthors.map(
-        async (author) =>
-          (await octokit.users.getByUsername({ username: author })).data
-      )
+      uniqueAuthors.map(async (author) => {
+        try {
+          return (await octokit.users.getByUsername({ username: author })).data;
+        } catch (error) {
+          return null as any;
+        }
+      })
     );
   }
 

--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -141,7 +141,7 @@ export class AutoMerger extends OpsBotPlugin {
       preserveNewlines: false,
     }).trim();
 
-    const authors = (await this.getAuthors(pr)).filter(author => !!author);
+    const authors = await this.getAuthors(pr);
     const approvers = await this.getApprovers(pr);
     const formatUserName = (user: UsersGetByUsernameResponseData): string => {
       if (user.name) {
@@ -199,15 +199,18 @@ export class AutoMerger extends OpsBotPlugin {
       uniqueAuthors.push(commitAuthor);
     }
 
-    return Promise.all(
-      uniqueAuthors.map(async (author) => {
-        try {
-          return (await octokit.users.getByUsername({ username: author })).data;
-        } catch (error) {
-          return null as any;
-        }
-      })
-    );
+    return (
+      await Promise.all(
+        uniqueAuthors.map(async (author) => {
+          try {
+            return (await octokit.users.getByUsername({ username: author }))
+              .data;
+          } catch (error) {
+            return null;
+          }
+        })
+      )
+    ).filter((x): x is UsersGetByUsernameResponseData => Boolean(x));
   }
 
   /**

--- a/test/auto_merger.test.ts
+++ b/test/auto_merger.test.ts
@@ -67,6 +67,7 @@ describe("Auto Merger", () => {
     mockGetByUsername.mockRejectedValueOnce(null);
     mockPaginate.mockResolvedValueOnce(list_reviews); // listReviews in getApprovers
     mockGetByUsername.mockResolvedValueOnce(user);
+    mockGetByUsername.mockRejectedValueOnce(null);
 
     await new AutoMerger(statusContext.successStatus).maybeMergePR();
 
@@ -119,6 +120,7 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
     mockGetByUsername.mockRejectedValueOnce(null);
     mockPaginate.mockResolvedValueOnce(list_reviews); // listReviews in getApprovers
     mockGetByUsername.mockResolvedValueOnce(user);
+    mockGetByUsername.mockRejectedValueOnce(null);
 
     await new AutoMerger(statusContext.successStatus).maybeMergePR();
 

--- a/test/auto_merger.test.ts
+++ b/test/auto_merger.test.ts
@@ -73,6 +73,7 @@ describe("Auto Merger", () => {
 
     expect(mockPullsGet).toBeCalledTimes(1);
     expect(mockPullsGet.mock.calls[0][0].pull_number).toBe(1234);
+    expect(mockGetByUsername).toBeCalledTimes(4);
 
     expect(mockMerge.mock.calls[0][0]).toMatchObject({
       owner: "rapidsai",
@@ -126,6 +127,7 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
 
     expect(mockPullsGet).toBeCalledTimes(1);
     expect(mockPullsGet.mock.calls[0][0].pull_number).toBe(1234);
+    expect(mockGetByUsername).toBeCalledTimes(4);
 
     expect(mockMerge.mock.calls[0][0]).toMatchObject({
       owner: "rapidsai",

--- a/test/auto_merger.test.ts
+++ b/test/auto_merger.test.ts
@@ -99,6 +99,11 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
       "Sample body text",
     ],
     [
+      "description only for bad user",
+      "This text {bad user returned} is skipped\n ## Description\nSample body text\n",
+      "Sample body text",
+    ],
+    [
       "description and checklist",
       "This text is skipped\n ## description\nSample body text\n ## checklist\n- [ ] Checklist item skipped 1\n- [ ] Checklist item skipped 2\n",
       "Sample body text",
@@ -114,7 +119,11 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
     mockPaginate.mockResolvedValueOnce(list_comments); // listComments in checkForValidMergeComment
     mockGetUserPermissionLevel.mockResolvedValueOnce(user_permission);
     mockPaginate.mockResolvedValueOnce(list_commits); // listCommits in getAuthors
-    mockGetByUsername.mockResolvedValueOnce(userNoName);
+    if (PR_body.includes("{bad user returned}")) {
+      mockGetByUsername.mockRejectedValueOnce(null)
+    } else {
+      mockGetByUsername.mockResolvedValueOnce(userNoName);
+    }
     mockPaginate.mockResolvedValueOnce(list_reviews); // listReviews in getApprovers
     mockGetByUsername.mockResolvedValueOnce(user);
 
@@ -133,8 +142,7 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
         expected_body +
         `
 
-Authors:
-  - https://github.com/VibhuJawa
+Authors:${PR_body.includes("{bad user returned}") ? "":"\n  - https://github.com/VibhuJawa"}
 
 Approvers:
   - Keith Kraus (https://github.com/kkraus14)

--- a/test/auto_merger.test.ts
+++ b/test/auto_merger.test.ts
@@ -64,6 +64,7 @@ describe("Auto Merger", () => {
     mockGetUserPermissionLevel.mockResolvedValueOnce(user_permission);
     mockPaginate.mockResolvedValueOnce(list_commits); // listCommits in getAuthors
     mockGetByUsername.mockResolvedValueOnce(userNoName);
+    mockGetByUsername.mockRejectedValueOnce(null);
     mockPaginate.mockResolvedValueOnce(list_reviews); // listReviews in getApprovers
     mockGetByUsername.mockResolvedValueOnce(user);
 
@@ -99,11 +100,6 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
       "Sample body text",
     ],
     [
-      "description only for bad user",
-      "This text {bad user returned} is skipped\n ## Description\nSample body text\n",
-      "Sample body text",
-    ],
-    [
       "description and checklist",
       "This text is skipped\n ## description\nSample body text\n ## checklist\n- [ ] Checklist item skipped 1\n- [ ] Checklist item skipped 2\n",
       "Sample body text",
@@ -119,11 +115,8 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
     mockPaginate.mockResolvedValueOnce(list_comments); // listComments in checkForValidMergeComment
     mockGetUserPermissionLevel.mockResolvedValueOnce(user_permission);
     mockPaginate.mockResolvedValueOnce(list_commits); // listCommits in getAuthors
-    if (PR_body.includes("{bad user returned}")) {
-      mockGetByUsername.mockRejectedValueOnce(null)
-    } else {
-      mockGetByUsername.mockResolvedValueOnce(userNoName);
-    }
+    mockGetByUsername.mockResolvedValueOnce(userNoName);
+    mockGetByUsername.mockRejectedValueOnce(null);
     mockPaginate.mockResolvedValueOnce(list_reviews); // listReviews in getApprovers
     mockGetByUsername.mockResolvedValueOnce(user);
 
@@ -142,7 +135,8 @@ URL: https://github.com/rapidsai/cudf/pull/6775`,
         expected_body +
         `
 
-Authors:${PR_body.includes("{bad user returned}") ? "":"\n  - https://github.com/VibhuJawa"}
+Authors:
+  - https://github.com/VibhuJawa
 
 Approvers:
   - Keith Kraus (https://github.com/kkraus14)

--- a/test/fixtures/responses/list_commits.json
+++ b/test/fixtures/responses/list_commits.json
@@ -27,7 +27,7 @@
     {
       "sha": "0ddcf220b748a343f78941ecb30ddcfb92f76441",
       "author": {
-        "login": "VibhuJawa"
+        "login": "another_user"
       }
     },
     {

--- a/test/fixtures/responses/list_reviews.json
+++ b/test/fixtures/responses/list_reviews.json
@@ -16,5 +16,11 @@
       "login": "VibhuJawa"
     },
     "state": "APPROVED"
+  },
+  {
+    "user": {
+      "login": "another_user"
+    },
+    "state": "APPROVED"
   }
 ]


### PR DESCRIPTION
This PR ensures that `ops-bot` does not crash when attempting to get user information. We have seen a case where Github returned a `400` where there was bad user information.