### PR TITLE
Log forward-merger error

### DIFF
--- a/src/plugins/ForwardMerger/forward_merger.ts
+++ b/src/plugins/ForwardMerger/forward_merger.ts
@@ -68,6 +68,7 @@ export class ForwardMerger extends OpsBotPlugin {
         sha: pr.head.sha,
       });
     } catch (error) {
+      this.logger.info(`Error during forward-merge: ${JSON.stringify(error)}`)
       await this.issueComment(
         pr.number,
         "**FAILURE** - Unable to forward-merge due to an error, **manual** merge is necessary. Do not use the `Resolve conflicts` option in this PR, follow these instructions https://docs.rapids.ai/maintainers/forward-merger/ \n\n**IMPORTANT**: When merging this PR, do not use the [auto-merger](https://docs.rapids.ai/resources/auto-merger/) (i.e. the `/merge` comment). Instead, an admin must manually merge by changing the merging strategy to `Create a Merge Commit`. Otherwise, history will be lost and the branches become incompatible."


### PR DESCRIPTION
In the case where a forward merger fails, we don't get any clues in the logs as to why. This PR fixes that.