### PR TITLE
Use elevated actor to merge forward-mergers

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,3 +47,4 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          GPUTESTER_PAT: ${{ secrets.GPUTESTER_PAT }}

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -18,6 +18,7 @@ provider:
     APP_ID: ${env:APP_ID}
     WEBHOOK_SECRET: ${env:WEBHOOK_SECRET}
     PRIVATE_KEY: ${env:PRIVATE_KEY}
+    GPUTESTER_PAT: ${env:GPUTESTER_PAT}
   iam:
     role:
       statements:

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { initBranchChecker } from "./plugins/BranchChecker";
 import { initLabelChecker } from "./plugins/LabelChecker";
 import { initRecentlyUpdated } from "./plugins/RecentlyUpdated";
 import { initReleaseDrafter } from "./plugins/ReleaseDrafter";
-// import { initForwardMerger } from "./plugins/ForwardMerger";
+import { initForwardMerger } from "./plugins/ForwardMerger";
 
 export = (app: Probot) => {
   initBranchChecker(app);
@@ -28,6 +28,5 @@ export = (app: Probot) => {
   initReleaseDrafter(app);
   initAutoMerger(app);
   initRecentlyUpdated(app);
-  // TODO: Re-enable ForwardMerger once branch protection blocker is resolved
-  // initForwardMerger(app);
+  initForwardMerger(app);
 };

--- a/test/forward_merger.test.ts
+++ b/test/forward_merger.test.ts
@@ -126,6 +126,9 @@ describe("Forward Merger", () => {
     mockCreatePR.mockResolvedValue(pr);
 
     mockMerge.mockResolvedValue(true);
+    const mockNewClient = jest.fn().mockName("initNewClient");
+    mockNewClient.mockReturnValue({ pulls: { merge: mockMerge } });
+    forwardMerger.initNewClient = mockNewClient;
     const mockIssueComment = jest
       .fn()
       .mockName("issueComment")
@@ -162,7 +165,11 @@ describe("Forward Merger", () => {
       .mockReturnValue(nextBranch);
     const pr = { data: { number: 1, head: { sha: 123456 } } };
     mockCreatePR.mockResolvedValue(pr);
+
     mockMerge.mockRejectedValueOnce(new Error("error"));
+    const mockNewClient = jest.fn().mockName("initNewClient");
+    mockNewClient.mockReturnValue({ pulls: { merge: mockMerge } });
+    forwardMerger.initNewClient = mockNewClient;
     const mockIssueComment = jest
       .fn()
       .mockName("issueComment")


### PR DESCRIPTION
This solves the problem of `rapids-bot`'s failing attempts to merge forward-merger PRs. See https://nvidia.slack.com/archives/CJWBS14NB/p1710956582188569?thread_ts=1710857430.929599&cid=CJWBS14NB for context behind this implementation.

Test: 
PR failing due to checks/pending review: https://github.com/rapidsai/literate-octo-potato/pull/817
PR merged with elevated actor: https://github.com/rapidsai/literate-octo-potato/pull/822