### PR TITLE
fix label checker

### DIFF
--- a/src/plugins/LabelChecker/label_checker.ts
+++ b/src/plugins/LabelChecker/label_checker.ts
@@ -15,7 +15,7 @@
  */
 
 import { OpsBotPlugin } from "../../plugin";
-import { createSetCommitStatus, isGPUTesterPR } from "../../shared";
+import { createSetCommitStatus, isRapidsBotPR } from "../../shared";
 import { PRContext } from "../../types";
 
 export class LabelChecker extends OpsBotPlugin {
@@ -51,9 +51,9 @@ export class LabelChecker extends OpsBotPlugin {
       await new Promise((res) => setTimeout(res, 2000));
     }
 
-    if (isGPUTesterPR(context.payload.pull_request)) {
+    if (isRapidsBotPR(context.payload.pull_request)) {
       return await setCommitStatus(
-        "No labels necessary for GPUTester PRs",
+        "No labels necessary for rapids-bot PRs",
         "success"
       );
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -97,6 +97,12 @@ export const isGPUTesterPR = (
   return pullRequest.user?.login.toLowerCase() === "gputester";
 };
 
+export const isRapidsBotPR = (
+  pullRequest: Pick<PullsGetResponseData, "user">
+): boolean => {
+  return pullRequest.user?.login.toLowerCase() === "rapids-bot";
+};
+
 /**
  * Returns true if the payload associated with the provided context
  * is from a GitHub Pull Request (as opposed to a GitHub Issue).

--- a/test/label_checker.test.ts
+++ b/test/label_checker.test.ts
@@ -216,10 +216,10 @@ describe("Label Checker", () => {
     );
   });
 
-  test("correct labels - GPUTester PR", async () => {
+  test("correct labels - rapids-bot PR", async () => {
     const context = makePRContext({
       title: "[gpuCI] Forward-merge branch-0.18 to branch-0.19 [skip ci]",
-      user: "GPUtester",
+      user: "rapids-bot",
     });
     await new LabelChecker(context).checkLabels();
     expect(mockCreateCommitStatus).toBeCalledTimes(2);
@@ -232,7 +232,7 @@ describe("Label Checker", () => {
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].state).toBe("success");
     expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-      "No labels necessary for GPUTester PRs"
+      "No labels necessary for rapids-bot PRs"
     );
     expect(mockCreateCommitStatus.mock.calls[1][0].target_url).toBe(
       "https://docs.rapids.ai/resources/label-checker/"


### PR DESCRIPTION
PR updates the label checker plugin to correctly skip Forward Merger PRs.