### PR TITLE
Pin `serverless` framework version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
       - name: Install serverless framework
-        run: npm install -g serverless
+        run: npm install -g serverless@3
       - name: Test Probot
         run: npm run test
       - name: Build Probot


### PR DESCRIPTION
The `serverless` framework recently published V4, which includes the licensing changes outlined on the pages below:

- https://www.serverless.com/blog/serverless-framework-v4-a-new-model
- https://www.serverless.com/framework/docs-guides-upgrading-v4

The TL;DR is that V4 of the `serverless` framework is no longer free for organizations with $2M or greater annual revenue.

As a temporary workaround, we can pin to V3. V3 will continue to receive security updates and bug fixes throughout 2024.

We will likely need to make this change in a few different repositories.