### PR TITLE
Fix rapids-bot login name

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -100,7 +100,7 @@ export const isGPUTesterPR = (
 export const isRapidsBotPR = (
   pullRequest: Pick<PullsGetResponseData, "user">
 ): boolean => {
-  return pullRequest.user?.login.toLowerCase() === "rapids-bot";
+  return pullRequest.user?.login.toLowerCase() === "rapids-bot[bot]";
 };
 
 /**

--- a/test/label_checker.test.ts
+++ b/test/label_checker.test.ts
@@ -219,7 +219,7 @@ describe("Label Checker", () => {
   test("correct labels - rapids-bot PR", async () => {
     const context = makePRContext({
       title: "[gpuCI] Forward-merge branch-0.18 to branch-0.19 [skip ci]",
-      user: "rapids-bot",
+      user: "rapids-bot[bot]",
     });
     await new LabelChecker(context).checkLabels();
     expect(mockCreateCommitStatus).toBeCalledTimes(2);


### PR DESCRIPTION
The actual login name is `rapids-bot[bot]`. PR adjusts the code accordingly.

Example command to verify:
```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/rapidsai/cugraph/pulls/4433
```