### PR TITLE
Allow ops-bot to merge to main if main is the default branch.

### DIFF
--- a/src/plugins/AutoMerger/auto_merger.ts
+++ b/src/plugins/AutoMerger/auto_merger.ts
@@ -56,7 +56,7 @@ export class AutoMerger extends OpsBotPlugin {
       });
 
       // Check if PR is mergeable (all green)
-      if (!this.isPrMergeable(pr)) {
+      if (!this.isPrMergeable(pr, repo.default_branch)) {
         this.logger.info({ pr }, "PR not mergeable");
         return;
       }
@@ -97,14 +97,14 @@ export class AutoMerger extends OpsBotPlugin {
    *
    * @param pr
    */
-  isPrMergeable(pr: PullsGetResponseData): boolean {
+  isPrMergeable(pr: PullsGetResponseData, default_branch: string): boolean {
     const mergeable_state = pr.mergeable_state;
     const mergeable = pr.mergeable;
     const baseRef = pr.base.ref;
     return (
       (mergeable_state === "clean" || mergeable_state === "unstable") &&
       mergeable === true &&
-      baseRef !== "main"
+      (baseRef !== "main" || default_branch === "main")
     );
   }
 


### PR DESCRIPTION
This attempts to solve an issue we saw with pynvjitlink where `/merge` didn't work because the default branch is `main` for that repo. This changes the behavior of the auto-merge to allow merging to `main` if it is the default branch for a repository.
