### PR TITLE
remove quotes from regex

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -57,7 +57,7 @@ export const isVersionedBranch = (branchName: string): boolean => {
  * @param branchName
  */
 export const isVersionedUCXBranch = (branchName: string): boolean => {
-  const regex = "/^branch-\d{1,2}\.\d\d$/";
+  const regex = /^branch-\d{1,2}\.\d\d$/;
   return Boolean(branchName.match(regex));
 };
 


### PR DESCRIPTION
Double quotes causes the strings which should otherwise pass, to fail the regex check 