### PR TITLE
Fix branches filter to discover ucx versioned branches

### DIFF
--- a/src/plugins/ForwardMerger/forward_merger.ts
+++ b/src/plugins/ForwardMerger/forward_merger.ts
@@ -98,7 +98,7 @@ export class ForwardMerger extends OpsBotPlugin {
       }
     );
     return branches
-      .filter((branch) => isVersionedBranch(branch.name))
+      .filter((branch) => isVersionedBranch(branch.name) || isVersionedUCXBranch(branch.name))
       .map((branch) => branch.name);
   }
 


### PR DESCRIPTION
This fixes a logical bug where we filter the returned branches list with only the RAPIDS versioning compatible regex.