### PR TITLE
fix recently updated PR checker

### DIFF
--- a/src/plugins/RecentlyUpdated/check_pr.ts
+++ b/src/plugins/RecentlyUpdated/check_pr.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createSetCommitStatus, isGPUTesterPR } from "../../shared";
+import { createSetCommitStatus, isRapidsBotPR } from "../../shared";
 import { PRContext, PullsListResponseData } from "../../types";
 import { Context } from "probot";
 import { OpsBotPlugin } from "../../plugin";
@@ -40,8 +40,8 @@ export const checkPR = async function (
 
   await setCommitStatus("Checking if PR has recent updates...", "pending");
 
-  if (isGPUTesterPR(pr)) {
-    await setCommitStatus("Automated GPUTester PR detected", "success");
+  if (isRapidsBotPR(pr)) {
+    await setCommitStatus("Automated rapids-bot PR detected", "success");
     return;
   }
 

--- a/test/fixtures/responses/list_pulls.json
+++ b/test/fixtures/responses/list_pulls.json
@@ -25,9 +25,9 @@
   "recently_updated": [
     {
       "number": 1234,
-      "title": "[RELEASE] cuml v0.18",
+      "title": "Forward-merge branch-0.17 to branch-0.18 [skip ci]",
       "user": {
-        "login": "GPUtester"
+        "login": "rapids-bot[bot]"
       },
       "labels": [{ "name": "breaking" }, { "name": "bug" }],
       "merged_at": "2021-01-27T13:38:56Z",

--- a/test/recently_updated.test.ts
+++ b/test/recently_updated.test.ts
@@ -48,10 +48,10 @@ describe("Recently Updated", () => {
       );
     });
 
-    test("release PR", async () => {
+    test("Forward Merge PR", async () => {
       const context = makePRContext({
-        title: "[RELEASE] cuml v0.18",
-        user: "GPUtester",
+        title: "Forward-merge branch-0.17 to branch-0.18 [skip ci]",
+        user: "rapids-bot[bot]",
       });
       await new PRRecentlyUpdated(context).checkPR();
       expect(mockCreateCommitStatus).toBeCalledTimes(2);
@@ -61,7 +61,7 @@ describe("Recently Updated", () => {
         "https://docs.rapids.ai/resources/recently-updated/"
       );
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Automated GPUTester PR detected"
+        "Automated rapids-bot PR detected"
       );
     });
 
@@ -124,7 +124,7 @@ describe("Recently Updated", () => {
         "https://docs.rapids.ai/resources/recently-updated/"
       );
       expect(mockCreateCommitStatus.mock.calls[1][0].description).toBe(
-        "Automated GPUTester PR detected"
+        "Automated rapids-bot PR detected"
       );
     });
 


### PR DESCRIPTION
Updates the `recently_updated` plugin to correctly filter out forward merger PRs.